### PR TITLE
Melee descriptions and crates Z level.

### DIFF
--- a/content/Entities/Items/Crate/prefab.crate.hjson
+++ b/content/Entities/Items/Crate/prefab.crate.hjson
@@ -28,6 +28,7 @@ holdable:
 
 sprite.renderer:
 {
+	z: 10.000
 	texture: "crate"
 }
 

--- a/content/Entities/Items/Shipment/prefab.shipment.hjson
+++ b/content/Entities/Items/Shipment/prefab.shipment.hjson
@@ -20,6 +20,7 @@ holdable:
 
 sprite.renderer:
 {
+	z: 10.000
 	texture: "shipment"
 }
 

--- a/content/Entities/Items/TrashCan/prefab.trashcan.hjson
+++ b/content/Entities/Items/TrashCan/prefab.trashcan.hjson
@@ -34,6 +34,7 @@ holdable:
 
 sprite.renderer:
 {
+	z: 10.000
 	texture: "trashcan"
 }
 

--- a/content/Entities/Tools/Melee.cs
+++ b/content/Entities/Tools/Melee.cs
@@ -49,7 +49,7 @@ namespace TC2.Base.Components
 			[Statistics.Info("Penetration Falloff", description: "Multiplies damage after each penetration", format: "{0:P2}", comparison: Statistics.Comparison.Lower)]
 			public float penetration_falloff;
 
-			[Statistics.Info("Penetration", description: "How many things this weapon can hit at once", format: "{0:0}", comparison: Statistics.Comparison.Higher)]
+			[Statistics.Info("Penetration", description: "How many things can be hit after one another", format: "{0:0}", comparison: Statistics.Comparison.Higher)]
 			public int penetration;
 
 			[Statistics.Info("Damage Type", description: "What kind of damage it deals", format: "{0}", comparison: Statistics.Comparison.None)]

--- a/content/Entities/Tools/Melee.cs
+++ b/content/Entities/Tools/Melee.cs
@@ -13,10 +13,10 @@ namespace TC2.Base.Components
 			public Vector2 swing_offset = new(1.00f, 1.00f);
 			public float swing_rotation = -2.50f;
 
-			[Statistics.Info("Base Damage", description: "Base Damage", format: "{0:0}", comparison: Statistics.Comparison.Higher)]
+			[Statistics.Info("Base Damage", description: "Base damage", format: "{0:0}", comparison: Statistics.Comparison.Higher)]
 			public float damage_base;
 
-			[Statistics.Info("Bonus Damage", description: "Random Additional Damage", format: "{0:0}", comparison: Statistics.Comparison.Higher)]
+			[Statistics.Info("Bonus Damage", description: "Random additional damage", format: "{0:0}", comparison: Statistics.Comparison.Higher)]
 			public float damage_bonus;
 
 			[Statistics.Info("Primary Damage Multiplier", description: "TODO: Desc", format: "{0:0}", comparison: Statistics.Comparison.Higher)]
@@ -31,28 +31,28 @@ namespace TC2.Base.Components
 			[Statistics.Info("Cooldown", description: "Time between attacks", format: "{0:0.##}s", comparison: Statistics.Comparison.Lower)]
 			public float cooldown;
 
-			[Statistics.Info("Reach", description: "How far away the weapon can deal damage", format: "{0:0.##}", comparison: Statistics.Comparison.Higher)]
+			[Statistics.Info("Reach", description: "Melee weapon range", format: "{0:0.##}", comparison: Statistics.Comparison.Higher)]
 			public float max_distance;
 
-			[Statistics.Info("Area of Effect", description: "When the weapon hits it deals damage in this area", format: "{0:0.##}", comparison: Statistics.Comparison.Higher)]
+			[Statistics.Info("Area of Effect", description: "Size of the affected area", format: "{0:0.##}", comparison: Statistics.Comparison.Higher)]
 			public float aoe;
 
-			[Statistics.Info("Thickness", description: "How far above and below the aim direction it will still hit", format: "{0:0.##}", comparison: Statistics.Comparison.Higher)]
+			[Statistics.Info("Thickness", description: "TODO: Desc", format: "{0:0.##}", comparison: Statistics.Comparison.Higher)]
 			public float thickness = 0.30f;
 
-			[Statistics.Info("Knockback", description: "Multiplies the Knockback of the damage", format: "{0:0.##}x", comparison: Statistics.Comparison.Higher)]
+			[Statistics.Info("Knockback", description: "Multiplies the knockback of the damage", format: "{0:0.##}x", comparison: Statistics.Comparison.Higher)]
 			public float knockback;
 
-			[Statistics.Info("Yield", description: "How much materials are gained when attacking trees and similar", format: "{0:P2}", comparison: Statistics.Comparison.Higher)]
+			[Statistics.Info("Yield", description: "Affects amount of material obtained from harvesting", format: "{0:P2}", comparison: Statistics.Comparison.Higher)]
 			public float yield;
 
-			[Statistics.Info("Penetration Falloff", description: "Multiplies damage after each penetration", format: "{0:P2}", comparison: Statistics.Comparison.Lower)]
+			[Statistics.Info("Penetration Falloff", description: "Modifies damage after each penetration", format: "{0:P2}", comparison: Statistics.Comparison.Lower)]
 			public float penetration_falloff;
 
-			[Statistics.Info("Penetration", description: "How many things can be hit after one another", format: "{0:0}", comparison: Statistics.Comparison.Higher)]
+			[Statistics.Info("Penetration", description: "How many objects are hit in single strike", format: "{0:0}", comparison: Statistics.Comparison.Higher)]
 			public int penetration;
 
-			[Statistics.Info("Damage Type", description: "What kind of damage it deals", format: "{0}", comparison: Statistics.Comparison.None)]
+			[Statistics.Info("Damage Type", description: "Type of damage dealt", format: "{0}", comparison: Statistics.Comparison.None)]
 			public Damage.Type damage_type;
 
 			public Physics.Layer hit_mask;

--- a/content/Entities/Tools/Melee.cs
+++ b/content/Entities/Tools/Melee.cs
@@ -37,7 +37,7 @@ namespace TC2.Base.Components
 			[Statistics.Info("Area of Effect", description: "When the weapon hits it deals damage in this area", format: "{0:0.##}", comparison: Statistics.Comparison.Higher)]
 			public float aoe;
 
-			[Statistics.Info("Thickness", description: "Thickness of the damage", format: "{0:0.##}", comparison: Statistics.Comparison.Higher)]
+			[Statistics.Info("Thickness", description: "How far above and below the aim direction it will still hit", format: "{0:0.##}", comparison: Statistics.Comparison.Higher)]
 			public float thickness = 0.30f;
 
 			[Statistics.Info("Knockback", description: "Multiplies the Knockback of the damage", format: "{0:0.##}x", comparison: Statistics.Comparison.Higher)]

--- a/content/Entities/Tools/Melee.cs
+++ b/content/Entities/Tools/Melee.cs
@@ -13,10 +13,10 @@ namespace TC2.Base.Components
 			public Vector2 swing_offset = new(1.00f, 1.00f);
 			public float swing_rotation = -2.50f;
 
-			[Statistics.Info("Base Damage", description: "TODO: Desc", format: "{0:0}", comparison: Statistics.Comparison.Higher)]
+			[Statistics.Info("Base Damage", description: "Base Damage", format: "{0:0}", comparison: Statistics.Comparison.Higher)]
 			public float damage_base;
 
-			[Statistics.Info("Bonus Damage", description: "TODO: Desc", format: "{0:0}", comparison: Statistics.Comparison.Higher)]
+			[Statistics.Info("Bonus Damage", description: "Random Additional Damage", format: "{0:0}", comparison: Statistics.Comparison.Higher)]
 			public float damage_bonus;
 
 			[Statistics.Info("Primary Damage Multiplier", description: "TODO: Desc", format: "{0:0}", comparison: Statistics.Comparison.Higher)]
@@ -25,34 +25,34 @@ namespace TC2.Base.Components
 			[Statistics.Info("Secondary Damage Multiplier", description: "TODO: Desc", format: "{0:0}", comparison: Statistics.Comparison.Higher)]
 			public float secondary_damage_multiplier = 1.00f;
 
-			[Statistics.Info("Terrain Damage Multiplier", description: "TODO: Desc", format: "{0:0}", comparison: Statistics.Comparison.Higher)]
+			[Statistics.Info("Terrain Damage Multiplier", description: "Damage to terrain", format: "{0:0}", comparison: Statistics.Comparison.Higher)]
 			public float terrain_damage_multiplier = 1.00f;
 
-			[Statistics.Info("Cooldown", description: "TODO: Desc", format: "{0:0.##}s", comparison: Statistics.Comparison.Lower)]
+			[Statistics.Info("Cooldown", description: "Time between attacks", format: "{0:0.##}s", comparison: Statistics.Comparison.Lower)]
 			public float cooldown;
 
-			[Statistics.Info("Reach", description: "TODO: Desc", format: "{0:0.##}", comparison: Statistics.Comparison.Higher)]
+			[Statistics.Info("Reach", description: "How far away the weapon can deal damage", format: "{0:0.##}", comparison: Statistics.Comparison.Higher)]
 			public float max_distance;
 
-			[Statistics.Info("Area of Effect", description: "TODO: Desc", format: "{0:0.##}", comparison: Statistics.Comparison.Higher)]
+			[Statistics.Info("Area of Effect", description: "When the weapon hits it deals damage in this area", format: "{0:0.##}", comparison: Statistics.Comparison.Higher)]
 			public float aoe;
 
-			[Statistics.Info("Thickness", description: "TODO: Desc", format: "{0:0.##}", comparison: Statistics.Comparison.Higher)]
+			[Statistics.Info("Thickness", description: "Thickness of the damage", format: "{0:0.##}", comparison: Statistics.Comparison.Higher)]
 			public float thickness = 0.30f;
 
-			[Statistics.Info("Knockback", description: "TODO: Desc", format: "{0:0.##}x", comparison: Statistics.Comparison.Higher)]
+			[Statistics.Info("Knockback", description: "Multiplies the Knockback of the damage", format: "{0:0.##}x", comparison: Statistics.Comparison.Higher)]
 			public float knockback;
 
-			[Statistics.Info("Yield", description: "TODO: Desc", format: "{0:P2}", comparison: Statistics.Comparison.Higher)]
+			[Statistics.Info("Yield", description: "How much materials are gained when attacking trees and similar", format: "{0:P2}", comparison: Statistics.Comparison.Higher)]
 			public float yield;
 
-			[Statistics.Info("Penetration Falloff", description: "TODO: Desc", format: "{0:P2}", comparison: Statistics.Comparison.Lower)]
+			[Statistics.Info("Penetration Falloff", description: "Multiplies damage after each penetration", format: "{0:P2}", comparison: Statistics.Comparison.Lower)]
 			public float penetration_falloff;
 
-			[Statistics.Info("Penetration", description: "TODO: Desc", format: "{0:0}", comparison: Statistics.Comparison.Higher)]
+			[Statistics.Info("Penetration", description: "How many things this weapon can hit at once", format: "{0:0}", comparison: Statistics.Comparison.Higher)]
 			public int penetration;
 
-			[Statistics.Info("Damage Type", description: "TODO: Desc", format: "{0}", comparison: Statistics.Comparison.None)]
+			[Statistics.Info("Damage Type", description: "What kind of damage it deals", format: "{0}", comparison: Statistics.Comparison.None)]
 			public Damage.Type damage_type;
 
 			public Physics.Layer hit_mask;


### PR DESCRIPTION
Added descriptions to most melee attributes.

Shipments, crates and trash-cans now have a consistent z level of 10 allowing you to hide behind them more consistently instead of it being random dependant on whether you or they are spawned first.