### PR TITLE
Fuse Modification Fixes

### DIFF
--- a/content/Data/Modifications.cs
+++ b/content/Data/Modifications.cs
@@ -32,7 +32,7 @@ namespace TC2.Base
 
 				apply: static (ref Fuse.Data data, ref Modification.Handle handle, Span<Modification.Handle> modifications) =>
 				{
-					ref var value = ref handle.GetData<float>();
+					var value = MathF.Max(0.50f, handle.GetData<float>());
 					data.time = value;
 				}
 			));

--- a/content/Data/Modifications.cs
+++ b/content/Data/Modifications.cs
@@ -12,6 +12,16 @@ namespace TC2.Base
 				name: "Fuse Length",
 				description: "Modifies fuse's length.",
 
+				can_add: static (in Health.Data data, ref Modification.Handle handle, Span<Modification.Handle> modifications) =>
+				{
+					var count = 0;
+					for (int i = 0; i < modifications.Length; i++)
+					{
+						if (modifications[i].id == handle.id) count++;
+					}
+					return count < 1;
+				},
+
 #if CLIENT
 				draw_editor: static (in Fuse.Data data, ref Modification.Handle handle, Span<Modification.Handle> modifications) =>
 				{
@@ -32,6 +42,16 @@ namespace TC2.Base
 				identifier: "fuse.inextinguishable",
 				name: "Inextinguishable Fuse",
 				description: "Makes the fuse impossible to be extinguished.",
+
+				can_add: static (in Health.Data data, ref Modification.Handle handle, Span<Modification.Handle> modifications) =>
+				{
+					var count = 0;
+					for (int i = 0; i < modifications.Length; i++)
+					{
+						if (modifications[i].id == handle.id) count++;
+					}
+					return count < 1;
+				},
 
 				apply: static (ref Fuse.Data data, ref Modification.Handle handle, Span<Modification.Handle> modifications) =>
 				{

--- a/content/Data/Modifications.cs
+++ b/content/Data/Modifications.cs
@@ -12,7 +12,7 @@ namespace TC2.Base
 				name: "Fuse Length",
 				description: "Modifies fuse's length.",
 
-				can_add: static (in Health.Data data, ref Modification.Handle handle, Span<Modification.Handle> modifications) =>
+				can_add: static (in Fuse.Data data, ref Modification.Handle handle, Span<Modification.Handle> modifications) =>
 				{
 					var count = 0;
 					for (int i = 0; i < modifications.Length; i++)
@@ -43,7 +43,7 @@ namespace TC2.Base
 				name: "Inextinguishable Fuse",
 				description: "Makes the fuse impossible to be extinguished.",
 
-				can_add: static (in Health.Data data, ref Modification.Handle handle, Span<Modification.Handle> modifications) =>
+				can_add: static (in Fuse.Data data, ref Modification.Handle handle, Span<Modification.Handle> modifications) =>
 				{
 					var count = 0;
 					for (int i = 0; i < modifications.Length; i++)


### PR DESCRIPTION
2 fuse modifiers can no longer be added multiple times (since they had no effect if you did)
fuse length modifier can no longer be set to 0