### PR TITLE
"Air-Cooled", "Slower Cycling Mechanism" modifiers

### DIFF
--- a/content/Data/Modifications.Gun.cs
+++ b/content/Data/Modifications.Gun.cs
@@ -1285,6 +1285,107 @@ namespace TC2.Base
 
 			definitions.Add(Modification.Definition.New<Gun.Data>
 			(
+				identifier: "gun.slower_cycling_mechanism",
+				name: "Slower Cycling Mechanism",
+				description: "Decreases fire rate, but increases reliability.",
+
+				validate: static (ref Modification.Context context, in Gun.Data data, ref Modification.Handle handle, Span<Modification.Handle> modifications) =>
+				{
+					ref var amount = ref handle.GetData<float>();
+					amount = Maths.Clamp(amount, 1.00f, 2.00f);
+
+					return true;
+				},
+
+				can_add: static (ref Modification.Context context, in Gun.Data data, ref Modification.Handle handle, Span<Modification.Handle> modifications) =>
+				{
+					return !modifications.HasModification(handle);
+				},
+
+#if CLIENT
+				draw_editor: static (ref Modification.Context context, in Gun.Data data, ref Modification.Handle handle, Span<Modification.Handle> modifications) =>
+				{
+					ref var value = ref handle.GetData<float>();
+					return GUI.SliderFloat("##stuff", ref value, 1.00f, 2.00f, "%.2f");
+				},
+#endif
+
+				apply_0: static (ref Modification.Context context, ref Gun.Data data, ref Modification.Handle handle, Span<Modification.Handle> modifications) =>
+				{
+					ref var value = ref handle.GetData<float>();
+					var ratio = value - 1.00f;
+
+					switch (data.type)
+					{
+						case Gun.Type.Handgun:
+						{
+							var mult = 1.00f - ratio;
+
+							data.failure_rate *= 0.85f;
+							data.failure_rate -= MathF.Min(data.failure_rate, 0.05f);
+							data.stability *= MathF.Pow(Maths.Clamp(data.stability, 0.00f, 1.00f), 2.00f);
+							data.cycle_interval *= Maths.Lerp(1.20f, 10.00f, ratio);
+						}
+						break;
+
+						case Gun.Type.Rifle:
+						{
+							var mult = 1.00f - ratio;
+
+							data.failure_rate *= 0.85f;
+							data.failure_rate -= MathF.Min(data.failure_rate, 0.05f);
+							data.stability *= MathF.Pow(Maths.Clamp(data.stability, 0.00f, 1.00f), 2.00f);
+							data.cycle_interval *= Maths.Lerp(1.20f, 5.00f, ratio);
+						}
+						break;
+
+						case Gun.Type.Shotgun:
+						{
+							data.failure_rate *= 0.85f;
+							data.failure_rate -= MathF.Min(data.failure_rate, 0.05f);
+							data.stability *= MathF.Pow(Maths.Clamp(data.stability, 0.00f, 1.00f), 2.00f);
+							data.cycle_interval *= Maths.Lerp(1.20f, 5.00f, ratio);
+						}
+						break;
+
+						case Gun.Type.SMG:
+						{
+							data.failure_rate *= 0.85f;
+							data.failure_rate -= MathF.Min(data.failure_rate, 0.05f);
+							data.stability *= MathF.Pow(Maths.Clamp(data.stability, 0.00f, 1.00f), 2.00f);
+							data.cycle_interval *= Maths.Lerp(1.20f, 10.00f, ratio);
+						}
+						break;
+
+						default:
+						{
+							data.failure_rate *= 0.85f;
+							data.failure_rate -= MathF.Min(data.failure_rate, 0.05f);
+							data.stability *= MathF.Pow(Maths.Clamp(data.stability, 0.00f, 1.00f), 2.00f);
+							data.cycle_interval *= Maths.Lerp(1.20f, 10.00f, ratio);
+						}
+						break;
+					}
+
+					switch (data.action)
+					{
+						case Gun.Action.Blowback:
+						{
+							data.cycle_interval *= 1.20f;
+						}
+						break;
+
+						case Gun.Action.Gas:
+						{
+							data.cycle_interval *= 1.14f;
+						}
+						break;
+					}
+				}
+			));
+
+			definitions.Add(Modification.Definition.New<Gun.Data>
+			(
 				identifier: "gun.gas_operation",
 				name: "Action: Gas-Operated",
 				description: "Converts to gas-operated action.",

--- a/content/Data/Modifications.cs
+++ b/content/Data/Modifications.cs
@@ -281,6 +281,50 @@ namespace TC2.Base
 
 			definitions.Add(Modification.Definition.New<Overheat.Data>
 			(
+				identifier: "overheat.air_coolant",
+				category: "Cooling",
+				name: "Air-Cooled",
+				description: "Increases cooling rate.",
+
+				validate: static (ref Modification.Context context, in Overheat.Data data, ref Modification.Handle handle, Span<Modification.Handle> modifications) =>
+				{
+					ref var amount = ref handle.GetData<int>();
+					amount = Maths.Clamp(amount, 1, 10);
+
+					return true;
+				},
+
+#if CLIENT
+				draw_editor: static (ref Modification.Context context, in Overheat.Data data, ref Modification.Handle handle, Span<Modification.Handle> modifications) =>
+				{
+					ref var amount = ref handle.GetData<int>();
+					return GUI.SliderInt("##stuff", ref amount, 1, 10, "%d");
+				},
+#endif
+
+				apply_0: static (ref Modification.Context context, ref Overheat.Data data, ref Modification.Handle handle, Span<Modification.Handle> modifications) =>
+				{
+					ref var amount = ref handle.GetData<int>();
+					data.cool_rate += amount * 9.00f;
+				},
+
+				apply_1: static (ref Modification.Context context, ref Overheat.Data data, ref Modification.Handle handle, Span<Modification.Handle> modifications) =>
+				{
+					ref var amount = ref handle.GetData<int>();
+
+					context.requirements_new.Add(Crafting.Requirement.Resource("iron_ingot", amount));
+
+					ref var body = ref context.GetComponent<Body.Data>();
+					if (!body.IsNull())
+					{
+						ref var material = ref Material.GetMaterial("iron_ingot");
+						body.mass_extra += amount * material.mass_per_unit;
+					}
+				}
+			));
+
+			definitions.Add(Modification.Definition.New<Overheat.Data>
+			(
 				identifier: "overheat.heat_resistant",
 				category: "Cooling",
 				name: "Heat-Resistant Components",


### PR DESCRIPTION
"Air-Cooled" modifier: makes cooling a gun or tool easier, has less weight penalty than "Water-cooling", slightly more efficient per weight but has less potential of cooling a gun or tool per modifier slot, very hefty cost of iron ingots (you could make another gun with those iron ingots instead), overall very useful for hand held fast fire rate firearms (like SMG or Machine Pistol, or MG converted to use HC rounds, etc), but loses to "Water-cooling" when used on mounted heavy guns

"Slower Cycling Mechanism" modifier: long awaited one, sets a fixed bonus on reliability and stability, but it has a slider to slow down the cycle speed, useful for big guns and automatic guns, especially for the high recoil ones, and when you want the gun to overheat slower due to lowered fire rate, also a good way to conserve ammo