### PR TITLE
Gun and ammo rework + bow buff

### DIFF
--- a/content/Entities/Guns/AutoShotgun/prefab.auto_shotgun.hjson
+++ b/content/Entities/Guns/AutoShotgun/prefab.auto_shotgun.hjson
@@ -41,7 +41,7 @@ gun:
 	sound_reload: "auto_shotgun_reload"
 	velocity_multiplier: 360.000
 	jitter_multiplier: 5.500
-	damage_multiplier: 1.200
+	damage_multiplier: 1.600
 	recoil_multiplier: 2.500
 	reload_interval: 2.500
 	cycle_interval: 0.500

--- a/content/Entities/Guns/BattleRifle/prefab.battle_rifle.hjson
+++ b/content/Entities/Guns/BattleRifle/prefab.battle_rifle.hjson
@@ -24,7 +24,7 @@ gun:
 	sound_empty: "gun_empty"
 	velocity_multiplier: 750.000
 	jitter_multiplier: 0.400
-	damage_multiplier: 3.300
+	damage_multiplier: 4.400
 	recoil_multiplier: 1.800
 	reload_interval: 2.000
 	cycle_interval: 0.400

--- a/content/Entities/Guns/Blunderbuss/prefab.blunderbuss.hjson
+++ b/content/Entities/Guns/Blunderbuss/prefab.blunderbuss.hjson
@@ -22,9 +22,9 @@ gun:
 	sound_shoot: "blunderbuss_shoot"
 	sound_cycle: "blunderbuss_cycle"
 	sound_reload: "blunderbuss_reload"
-	velocity_multiplier: 220.000
+	velocity_multiplier: 250.000
 	jitter_multiplier: 8.000
-	damage_multiplier: 3.300
+	damage_multiplier: 4.800
 	recoil_multiplier: 2.500
 	reload_interval: 2.000
 	cycle_interval: 0.500

--- a/content/Entities/Guns/Carbine/prefab.carbine.hjson
+++ b/content/Entities/Guns/Carbine/prefab.carbine.hjson
@@ -24,7 +24,7 @@ gun:
 	sound_reload: "rifle_reload"
 	velocity_multiplier: 640.000
 	jitter_multiplier: 0.200
-	damage_multiplier: 2.500
+	damage_multiplier: 3.200
 	recoil_multiplier: 2.300
 	reload_interval: 0.600
 	cycle_interval: 0.350

--- a/content/Entities/Guns/Crankgun/prefab.crankgun.hjson
+++ b/content/Entities/Guns/Crankgun/prefab.crankgun.hjson
@@ -21,9 +21,9 @@ gun:
 	muzzle_offset: [1.500, 0.000]
 	sound_shoot: "crankgun_shoot"
 	sound_reload: "missing"
-	velocity_multiplier: 650.000
+	velocity_multiplier: 750.000
 	jitter_multiplier: 0.800
-	damage_multiplier: 3.000
+	damage_multiplier: 4.400
 	recoil_multiplier: 4.000
 	reload_interval: 4.000
 	cycle_interval: 0.125

--- a/content/Entities/Guns/MachinePistol/prefab.machine_pistol.hjson
+++ b/content/Entities/Guns/MachinePistol/prefab.machine_pistol.hjson
@@ -24,7 +24,7 @@ gun:
 	sound_empty: "gun_empty"
 	velocity_multiplier: 280.000
 	jitter_multiplier: 0.600
-	damage_multiplier: 1.500
+	damage_multiplier: 2.750
 	recoil_multiplier: 0.200
 	reload_interval: 2.000
 	cycle_interval: 0.065

--- a/content/Entities/Guns/Pistol/prefab.pistol.hjson
+++ b/content/Entities/Guns/Pistol/prefab.pistol.hjson
@@ -24,7 +24,7 @@ gun:
 	sound_empty: "gun_empty"
 	velocity_multiplier: 280.000
 	jitter_multiplier: 0.300
-	damage_multiplier: 2.000
+	damage_multiplier: 2.750
 	recoil_multiplier: 0.300
 	reload_interval: 1.800
 	cycle_interval: 0.160

--- a/content/Entities/Guns/PumpShotgun/prefab.pump_shotgun.hjson
+++ b/content/Entities/Guns/PumpShotgun/prefab.pump_shotgun.hjson
@@ -34,7 +34,7 @@ gun:
 	sound_reload: "shotgun_reload"
 	velocity_multiplier: 400.000
 	jitter_multiplier: 5.500
-	damage_multiplier: 1.500
+	damage_multiplier: 2.000
 	recoil_multiplier: 2.500
 	reload_interval: 0.600
 	cycle_interval: 0.500

--- a/content/Entities/Guns/Scattergun/prefab.scattergun.hjson
+++ b/content/Entities/Guns/Scattergun/prefab.scattergun.hjson
@@ -24,7 +24,7 @@ gun:
 	sound_reload: "scattergun_reload"
 	velocity_multiplier: 360.000
 	jitter_multiplier: 10.000
-	damage_multiplier: 1.200
+	damage_multiplier: 1.600
 	recoil_multiplier: 2.800
 	reload_interval: 1.100
 	cycle_interval: 0.500

--- a/content/Entities/Projectiles/Arrow/prefab.projectile.arrow.hjson
+++ b/content/Entities/Projectiles/Arrow/prefab.projectile.arrow.hjson
@@ -2,8 +2,8 @@ $tags: []
 
 projectile:
 {
-	damage_base: 170.000
-	damage_bonus: 270.000
+	damage_base: 200.000
+	damage_bonus: 300.000
 	lifetime: 15.000
 	damage_type: arrow
 	size: 0.400

--- a/content/Entities/Projectiles/Bullet/prefab.projectile.bullet.lc.hjson
+++ b/content/Entities/Projectiles/Bullet/prefab.projectile.bullet.lc.hjson
@@ -3,7 +3,7 @@ $tags: []
 projectile:
 {
 	damage_base: 70.000
-	damage_bonus: 100.000
+	damage_bonus: 150.000
 	lifetime: 2.000
 	damage_type: bullet_lc
 	size: 0.125

--- a/content/Entities/Projectiles/Bullet/prefab.projectile.bullet.lc.hv.hjson
+++ b/content/Entities/Projectiles/Bullet/prefab.projectile.bullet.lc.hv.hjson
@@ -3,7 +3,7 @@ $tags: []
 projectile:
 {
 	damage_base: 130.000
-	damage_bonus: 200.000
+	damage_bonus: 300.000
 	lifetime: 2.000
 	damage_type: bullet_lc
 	size: 0.125

--- a/content/Entities/Projectiles/Bullet/prefab.projectile.bullet.mg.hjson
+++ b/content/Entities/Projectiles/Bullet/prefab.projectile.bullet.mg.hjson
@@ -2,8 +2,8 @@ $tags: []
 
 projectile:
 {
-	damage_base: 200.000
-	damage_bonus: 100.000
+	damage_base: 450.000
+	damage_bonus: 450.000
 	lifetime: 2.000
 	damage_type: bullet_mg
 	size: 0.250

--- a/content/Entities/Projectiles/Misc/prefab.projectile.musket.hjson
+++ b/content/Entities/Projectiles/Misc/prefab.projectile.musket.hjson
@@ -2,8 +2,8 @@ $tags: []
 
 projectile:
 {
-	damage_base: 60.000
-	damage_bonus: 150.000
+	damage_base: 100.000
+	damage_bonus: 240.000
 	lifetime: 5.000
 	damage_type: bullet_musket
 	size: 0.300

--- a/content/Entities/Projectiles/Misc/prefab.projectile.musket.scrapshot.hjson
+++ b/content/Entities/Projectiles/Misc/prefab.projectile.musket.scrapshot.hjson
@@ -3,7 +3,7 @@ $tags: []
 projectile:
 {
 	damage_base: 3.000
-	damage_bonus: 30.000
+	damage_bonus: 48.000
 	lifetime: 5.000
 	damage_type: bullet_sg
 	size: 0.100

--- a/content/Entities/Projectiles/Misc/prefab.projectile.musket.shot.hjson
+++ b/content/Entities/Projectiles/Misc/prefab.projectile.musket.shot.hjson
@@ -2,8 +2,8 @@ $tags: []
 
 projectile:
 {
-	damage_base: 25.000
-	damage_bonus: 50.000
+	damage_base: 50.000
+	damage_bonus: 80.000
 	lifetime: 5.000
 	damage_type: bullet_sg
 	size: 0.150


### PR DESCRIPTION
(Modern guns)

LC ammo (both variants): bonus damage is 1,5x of the previous value

MG ammo: increased damage and bonus damage, to make it a truly powerful round

Pistol: damage multiplier from 2x to 2,75x
Machine pistol: damage multiplier from 1,5x to 2,75x
Pump shotgun: damage multiplier from 1,5x to 2x
Scattergun: damage multiplier from 1,2x to 1,6x
Auto shotgun: damage multiplier from 1,2x to 1,6x
Carbine: damage multiplier from 2,5x to 3,2x
Battle rifle: damage multiplier from 3,3x to 4,4x
Crankgun: damage multiplier from 3x to 4,4x; muzzle velocity from 650 m/s to 750 m/s

(Caplock guns)

Musket ammo (all variants): slightly increased the base damage (except the scrapshot ammo), bonus damage is 1,6x of the previous value

Blunderbuss: damage multiplier from 3,3x to 4,8x; muzzle velocity from 220 m/s to 250 m/s
Bow: slightly increased damage and bonus damage

-----
These values are the result of careful testing, not only the guns were tested but the ammo variants as well, with focus on performance of default ammo and high velocity ammo fired by the same gun, multiple scenarios were tested, including:

- Scenario with shots fired as fast as the fire rate allows, targeted the body, or a head, or head and body randomly

- Scenario with shots fired relatively slowly to simulate the fight with accessible cover, targeted the body, or a head, or head and body

- Scenario with charging poh creature, where the various levels of its health condition were observed:
1) When it becomes slower than a running human
2) When it becomes slower than a crouching human
3) When it's fragged

- Scenario vs hornet

- A number of tests vs armor, with different gun and ammo combinations, different shot placement and fire rate

-----
The results:

- Ammo used is the most critical factor, followed by shot placement, and how fast the next shots will hit

- Despite the visually small difference of damage multipliers on guns, they play a huge role:
(Example: rifle deals much more pain levels than the battle rifle and carbine using the same ammo, leading to a much better performance vs armored target when using the rifle)

- Gunpowder ammo shot is very likely to be survived even without armor, thus making the gunpowder tech level combat last longer on average

- High velocity ammo is very dangerous, and it performs vs armor way better than gunpowder ammo (LC is partially blocked though)

- Musket ammo (shot variant too) is a surprisingly strong choice, somewhat compensating the single shot nature of stock caplock guns, scrapshot ammo is very random but still dangerous, performance vs armor is OK

- MG ammo is extremely dangerous (because it's similar to .50 BMG), the strongest choice vs armor short of autocannon

- Bow is now a bit more powerful, but it's still way more survivable than the guns

- Armor is very good, but it won't make the character wearing it invulnerable