### PR TITLE
Ammo crafting and weight rework, + tweaks

### DIFF
--- a/content/Materials/material.ammo_ac.he.hjson
+++ b/content/Materials/material.ammo_ac.he.hjson
@@ -10,8 +10,8 @@
 	
 	type: metal
 	flags: manufactured, ammo, ammo_ac, despawnable
-	mass_per_unit: 0.150
-	quantity_max: 50.000
+	mass_per_unit: 0.450
+	quantity_max: 10.000
 	prefab: "resource.ammo_ac.he"
 	
 	projectile_count: 1

--- a/content/Materials/material.ammo_ac.hjson
+++ b/content/Materials/material.ammo_ac.hjson
@@ -10,8 +10,8 @@
 	
 	type: metal
 	flags: manufactured, ammo, ammo_ac, despawnable
-	mass_per_unit: 0.200
-	quantity_max: 50.000
+	mass_per_unit: 0.450
+	quantity_max: 10.000
 	prefab: "resource.ammo_ac"
 	
 	projectile_count: 1

--- a/content/Materials/material.ammo_mg.hjson
+++ b/content/Materials/material.ammo_mg.hjson
@@ -14,8 +14,8 @@
 	
 	type: metal
 	flags: manufactured, ammo, ammo_mg, despawnable
-	mass_per_unit: 0.040
-	quantity_max: 100.000
+	mass_per_unit: 0.120
+	quantity_max: 25.000
 	prefab: "resource.ammo_mg"
 	
 	projectile_count: 1

--- a/content/Materials/material.ammo_musket.hjson
+++ b/content/Materials/material.ammo_musket.hjson
@@ -10,8 +10,8 @@
 	
 	type: metal
 	flags: manufactured, ammo, ammo_musket, despawnable
-	mass_per_unit: 0.030
-	quantity_max: 50.000
+	mass_per_unit: 0.090
+	quantity_max: 24.000
 	prefab: "resource.ammo_musket"
 	
 	projectile_count: 1

--- a/content/Materials/material.ammo_musket.scrapshot.hjson
+++ b/content/Materials/material.ammo_musket.scrapshot.hjson
@@ -10,8 +10,8 @@
 	
 	type: metal
 	flags: manufactured, ammo, ammo_musket, despawnable
-	mass_per_unit: 0.030
-	quantity_max: 50.000
+	mass_per_unit: 0.070
+	quantity_max: 24.000
 	prefab: "resource.ammo_musket.scrapshot"
 	
 	projectile_count: 8

--- a/content/Materials/material.ammo_musket.shot.hjson
+++ b/content/Materials/material.ammo_musket.shot.hjson
@@ -10,8 +10,8 @@
 	
 	type: metal
 	flags: manufactured, ammo, ammo_musket, despawnable
-	mass_per_unit: 0.030
-	quantity_max: 50.000
+	mass_per_unit: 0.090
+	quantity_max: 24.000
 	prefab: "resource.ammo_musket.shot"
 	
 	projectile_count: 4

--- a/content/Materials/material.ammo_sg.bird.gp.hjson
+++ b/content/Materials/material.ammo_sg.bird.gp.hjson
@@ -15,7 +15,7 @@
 	
 	type: metal
 	flags: manufactured, ammo, ammo_sg, despawnable
-	mass_per_unit: 0.020
+	mass_per_unit: 0.050
 	quantity_max: 24.000
 	prefab: "resource.ammo_sg.bird.gp"
 	

--- a/content/Materials/material.ammo_sg.bird.hjson
+++ b/content/Materials/material.ammo_sg.bird.hjson
@@ -14,7 +14,7 @@
 	
 	type: metal
 	flags: manufactured, ammo, ammo_sg, despawnable
-	mass_per_unit: 0.020
+	mass_per_unit: 0.050
 	quantity_max: 24.000
 	prefab: "resource.ammo_sg.bird"
 	

--- a/content/Materials/material.ammo_sg.buck.gp.hjson
+++ b/content/Materials/material.ammo_sg.buck.gp.hjson
@@ -15,7 +15,7 @@
 	
 	type: metal
 	flags: manufactured, ammo, ammo_sg, despawnable
-	mass_per_unit: 0.020
+	mass_per_unit: 0.050
 	quantity_max: 24.000
 	prefab: "resource.ammo_sg.buck.gp"
 	

--- a/content/Materials/material.ammo_sg.buck.hjson
+++ b/content/Materials/material.ammo_sg.buck.hjson
@@ -14,7 +14,7 @@
 	
 	type: metal
 	flags: manufactured, ammo, ammo_sg, despawnable
-	mass_per_unit: 0.020
+	mass_per_unit: 0.050
 	quantity_max: 24.000
 	prefab: "resource.ammo_sg.buck"
 	

--- a/content/Materials/material.ammo_sg.grenade.hjson
+++ b/content/Materials/material.ammo_sg.grenade.hjson
@@ -13,7 +13,7 @@
 	
 	type: metal
 	flags: manufactured, ammo, ammo_sg, despawnable
-	mass_per_unit: 0.100
+	mass_per_unit: 0.025
 	quantity_max: 24.000
 	prefab: "resource.ammo_sg.grenade"
 	

--- a/content/Materials/material.ammo_sg.slug.gp.hjson
+++ b/content/Materials/material.ammo_sg.slug.gp.hjson
@@ -15,7 +15,7 @@
 	
 	type: metal
 	flags: manufactured, ammo, ammo_sg, despawnable
-	mass_per_unit: 0.020
+	mass_per_unit: 0.050
 	quantity_max: 24.000
 	prefab: "resource.ammo_sg.slug.gp"
 	

--- a/content/Materials/material.ammo_sg.slug.hjson
+++ b/content/Materials/material.ammo_sg.slug.hjson
@@ -14,7 +14,7 @@
 	
 	type: metal
 	flags: manufactured, ammo, ammo_sg, despawnable
-	mass_per_unit: 0.020
+	mass_per_unit: 0.050
 	quantity_max: 24.000
 	prefab: "resource.ammo_sg.slug"
 	

--- a/content/Materials/material.ammo_shell.hjson
+++ b/content/Materials/material.ammo_shell.hjson
@@ -10,7 +10,7 @@
 	
 	type: metal
 	flags: manufactured, ammo, ammo_shell
-	mass_per_unit: 40.000
+	mass_per_unit: 10.000
 	quantity_max: 1.000
 	prefab: "resource.ammo_shell"
 	

--- a/content/Materials/material.ammo_shell.shrapnel.hjson
+++ b/content/Materials/material.ammo_shell.shrapnel.hjson
@@ -10,7 +10,7 @@
 	
 	type: metal
 	flags: manufactured, ammo, ammo_shell
-	mass_per_unit: 40.000
+	mass_per_unit: 10.000
 	quantity_max: 1.000
 	prefab: "resource.ammo_shell.shrapnel"
 	

--- a/content/Materials/material.gunpowder.hjson
+++ b/content/Materials/material.gunpowder.hjson
@@ -10,7 +10,7 @@
 	
 	type: powder
 	flags: manufactured, explosive, despawnable
-	mass_per_unit: 0.200
+	mass_per_unit: 0.100
 	quantity_max: 500.000
 	prefab: "resource.gunpowder"
 	

--- a/content/Materials/material.nitrocellulose.hjson
+++ b/content/Materials/material.nitrocellulose.hjson
@@ -11,7 +11,7 @@
 	type: powder
 	flags: manufactured, explosive
 	mass_per_unit: 0.100
-	quantity_max: 250.000
+	quantity_max: 500.000
 	prefab: "resource.nitrocellulose"
 	
 	projectile_count: 0

--- a/content/Modifications/Modifications.Gun.cs
+++ b/content/Modifications/Modifications.Gun.cs
@@ -504,6 +504,7 @@ namespace TC2.Base
 
 				can_add: static (ref Modification.Context context, in Gun.Data data, ref Modification.Handle handle, Span<Modification.Handle> modifications) =>
 				{
+					if (data.type == Gun.Type.AutoCannon) return false;
 					return !modifications.HasModification(handle) && data.ammo_filter.HasAny(Material.Flags.Ammo_LC | Material.Flags.Ammo_HC | Material.Flags.Ammo_MG | Material.Flags.Ammo_AC);
 				},
 

--- a/content/Recipes/Forge/recipe.forge.bomb.ball.hjson
+++ b/content/Recipes/Forge/recipe.forge.bomb.ball.hjson
@@ -20,7 +20,7 @@
 		{
 			type: "resource"
 			material: "gunpowder"
-			amount: 10.000
+			amount: 2.500
 		}
 		{
 			type: "resource"

--- a/content/Recipes/Gunsmith/recipe.gunsmith.ammo_ac.he.hjson
+++ b/content/Recipes/Gunsmith/recipe.gunsmith.ammo_ac.he.hjson
@@ -20,22 +20,22 @@
 		{
 			type: "resource"
 			material: "iron_ingot"
-			amount: 0.500
+			amount: 0.100
 		}
 		{
 			type: "resource"
 			material: "copper_ingot"
-			amount: 0.500
+			amount: 0.200
 		}
 		{
 			type: "resource"
 			material: "nitrocellulose"
-			amount: 2.000
+			amount: 4.000
 		}
 		{
 			type: "resource"
 			material: "nitroglycerine"
-			amount: 5.000
+			amount: 0.125
 		}
 		{
 			type: "work"

--- a/content/Recipes/Gunsmith/recipe.gunsmith.ammo_ac.hjson
+++ b/content/Recipes/Gunsmith/recipe.gunsmith.ammo_ac.hjson
@@ -20,17 +20,17 @@
 		{
 			type: "resource"
 			material: "iron_ingot"
-			amount: 1.500
+			amount: 0.300
 		}
 		{
 			type: "resource"
 			material: "copper_ingot"
-			amount: 0.500
+			amount: 0.200
 		}
 		{
 			type: "resource"
 			material: "nitrocellulose"
-			amount: 2.000
+			amount: 4.500
 		}
 		{
 			type: "work"

--- a/content/Recipes/Gunsmith/recipe.gunsmith.ammo_hc.hjson
+++ b/content/Recipes/Gunsmith/recipe.gunsmith.ammo_hc.hjson
@@ -14,9 +14,9 @@
 		frame: [3, 0]
 	}
 	
-	min: 10
+	min: 50
 	max: 500
-	step: 10
+	step: 50
 	type: workshop
 	tags: gunsmith
 	
@@ -25,23 +25,23 @@
 		{
 			type: "resource"
 			material: "iron_ingot"
-			amount: 0.200
+			amount: 0.030
 		}
 		{
 			type: "resource"
 			material: "copper_ingot"
-			amount: 0.100
+			amount: 0.010
 		}
 		{
 			type: "resource"
 			material: "gunpowder"
-			amount: 0.200
+			amount: 0.080
 		}
 		{
 			type: "work"
 			work: "assembling"
-			amount: 50.000
-			difficulty: 4.000
+			amount: 8.000
+			difficulty: 5.000
 		}
 	]
 	

--- a/content/Recipes/Gunsmith/recipe.gunsmith.ammo_hc.hv.hjson
+++ b/content/Recipes/Gunsmith/recipe.gunsmith.ammo_hc.hv.hjson
@@ -13,9 +13,9 @@
 		frame: [3, 0]
 	}
 	
-	min: 10
+	min: 50
 	max: 500
-	step: 10
+	step: 50
 	type: workshop
 	tags: gunsmith
 	
@@ -24,23 +24,23 @@
 		{
 			type: "resource"
 			material: "iron_ingot"
-			amount: 0.200
+			amount: 0.030
 		}
 		{
 			type: "resource"
 			material: "copper_ingot"
-			amount: 0.100
+			amount: 0.010
 		}
 		{
 			type: "resource"
 			material: "nitrocellulose"
-			amount: 0.200
+			amount: 0.080
 		}
 		{
 			type: "work"
 			work: "assembling"
-			amount: 50.000
-			difficulty: 4.000
+			amount: 8.000
+			difficulty: 5.000
 		}
 	]
 	

--- a/content/Recipes/Gunsmith/recipe.gunsmith.ammo_lc.hjson
+++ b/content/Recipes/Gunsmith/recipe.gunsmith.ammo_lc.hjson
@@ -14,9 +14,9 @@
 		frame: [3, 0]
 	}
 	
-	min: 10
+	min: 50
 	max: 500
-	step: 10
+	step: 50
 	type: workshop
 	tags: gunsmith
 	
@@ -25,22 +25,22 @@
 		{
 			type: "resource"
 			material: "iron_ingot"
-			amount: 0.050
+			amount: 0.015
 		}
 		{
 			type: "resource"
 			material: "copper_ingot"
-			amount: 0.050
+			amount: 0.015
 		}
 		{
 			type: "resource"
 			material: "gunpowder"
-			amount: 0.100
+			amount: 0.020
 		}
 		{
 			type: "work"
 			work: "assembling"
-			amount: 50.000
+			amount: 8.000
 			difficulty: 5.000
 		}
 	]

--- a/content/Recipes/Gunsmith/recipe.gunsmith.ammo_lc.hv.hjson
+++ b/content/Recipes/Gunsmith/recipe.gunsmith.ammo_lc.hv.hjson
@@ -13,9 +13,9 @@
 		frame: [3, 0]
 	}
 	
-	min: 10
+	min: 50
 	max: 500
-	step: 10
+	step: 50
 	type: workshop
 	tags: gunsmith
 	
@@ -24,22 +24,22 @@
 		{
 			type: "resource"
 			material: "iron_ingot"
-			amount: 0.050
+			amount: 0.015
 		}
 		{
 			type: "resource"
 			material: "copper_ingot"
-			amount: 0.050
+			amount: 0.015
 		}
 		{
 			type: "resource"
 			material: "nitrocellulose"
-			amount: 0.100
+			amount: 0.020
 		}
 		{
 			type: "work"
 			work: "assembling"
-			amount: 50.000
+			amount: 8.000
 			difficulty: 5.000
 		}
 	]

--- a/content/Recipes/Gunsmith/recipe.gunsmith.ammo_mg.hjson
+++ b/content/Recipes/Gunsmith/recipe.gunsmith.ammo_mg.hjson
@@ -20,17 +20,17 @@
 		{
 			type: "resource"
 			material: "iron_ingot"
-			amount: 0.400
+			amount: 0.160
 		}
 		{
 			type: "resource"
 			material: "copper_ingot"
-			amount: 0.150
+			amount: 0.050
 		}
 		{
 			type: "resource"
 			material: "nitrocellulose"
-			amount: 0.400
+			amount: 0.500
 		}
 		{
 			type: "work"

--- a/content/Recipes/Gunsmith/recipe.gunsmith.ammo_musket.hjson
+++ b/content/Recipes/Gunsmith/recipe.gunsmith.ammo_musket.hjson
@@ -25,18 +25,18 @@
 		{
 			type: "resource"
 			material: "iron_ingot"
-			amount: 0.100
+			amount: 0.050
 		}
 		{
 			type: "resource"
 			material: "gunpowder"
-			amount: 0.200
+			amount: 0.600
 		}
 		{
 			type: "work"
 			work: "assembling"
-			amount: 10.000
-			difficulty: 4.000
+			amount: 5.000
+			difficulty: 2.000
 		}
 	]
 	

--- a/content/Recipes/Gunsmith/recipe.gunsmith.ammo_musket.scrapshot.hjson
+++ b/content/Recipes/Gunsmith/recipe.gunsmith.ammo_musket.scrapshot.hjson
@@ -25,17 +25,17 @@
 		{
 			type: "resource"
 			material: "gravel"
-			amount: 0.300
+			amount: 0.100
 		}
 		{
 			type: "resource"
 			material: "gunpowder"
-			amount: 0.150
+			amount: 0.600
 		}
 		{
 			type: "work"
 			work: "assembling"
-			amount: 4.000
+			amount: 2.000
 			difficulty: 2.000
 		}
 	]

--- a/content/Recipes/Gunsmith/recipe.gunsmith.ammo_musket.shot.hjson
+++ b/content/Recipes/Gunsmith/recipe.gunsmith.ammo_musket.shot.hjson
@@ -25,18 +25,18 @@
 		{
 			type: "resource"
 			material: "iron_ingot"
-			amount: 0.100
+			amount: 0.050
 		}
 		{
 			type: "resource"
 			material: "gunpowder"
-			amount: 0.200
+			amount: 0.600
 		}
 		{
 			type: "work"
 			work: "assembling"
-			amount: 15.000
-			difficulty: 4.000
+			amount: 8.000
+			difficulty: 2.000
 		}
 	]
 	

--- a/content/Recipes/Gunsmith/recipe.gunsmith.ammo_sg.bird.gp.hjson
+++ b/content/Recipes/Gunsmith/recipe.gunsmith.ammo_sg.bird.gp.hjson
@@ -13,9 +13,9 @@
 		frame: [3, 0]
 	}
 	
-	min: 4
+	min: 10
 	max: 100
-	step: 4
+	step: 10
 	type: workshop
 	tags: gunsmith
 	
@@ -24,23 +24,23 @@
 		{
 			type: "resource"
 			material: "iron_ingot"
-			amount: 0.125
+			amount: 0.050
 		}
 		{
 			type: "resource"
 			material: "copper_ingot"
-			amount: 0.250
+			amount: 0.040
 		}
 		{
 			type: "resource"
 			material: "gunpowder"
-			amount: 0.250
+			amount: 0.040
 		}
 		{
 			type: "work"
 			work: "assembling"
-			amount: 60.000
-			difficulty: 5.000
+			amount: 8.000
+			difficulty: 4.000
 		}
 	]
 	

--- a/content/Recipes/Gunsmith/recipe.gunsmith.ammo_sg.bird.hjson
+++ b/content/Recipes/Gunsmith/recipe.gunsmith.ammo_sg.bird.hjson
@@ -13,9 +13,9 @@
 		frame: [3, 0]
 	}
 	
-	min: 4
+	min: 10
 	max: 100
-	step: 4
+	step: 10
 	type: workshop
 	tags: gunsmith
 	
@@ -24,23 +24,23 @@
 		{
 			type: "resource"
 			material: "iron_ingot"
-			amount: 0.125
+			amount: 0.050
 		}
 		{
 			type: "resource"
 			material: "copper_ingot"
-			amount: 0.250
+			amount: 0.040
 		}
 		{
 			type: "resource"
 			material: "nitrocellulose"
-			amount: 0.250
+			amount: 0.040
 		}
 		{
 			type: "work"
 			work: "assembling"
-			amount: 60.000
-			difficulty: 5.000
+			amount: 8.000
+			difficulty: 4.000
 		}
 	]
 	

--- a/content/Recipes/Gunsmith/recipe.gunsmith.ammo_sg.buck.gp.hjson
+++ b/content/Recipes/Gunsmith/recipe.gunsmith.ammo_sg.buck.gp.hjson
@@ -14,9 +14,9 @@
 		frame: [3, 0]
 	}
 	
-	min: 4
+	min: 10
 	max: 100
-	step: 4
+	step: 10
 	type: workshop
 	tags: gunsmith
 	
@@ -25,23 +25,23 @@
 		{
 			type: "resource"
 			material: "iron_ingot"
-			amount: 0.125
+			amount: 0.050
 		}
 		{
 			type: "resource"
 			material: "copper_ingot"
-			amount: 0.250
+			amount: 0.040
 		}
 		{
 			type: "resource"
 			material: "gunpowder"
-			amount: 0.250
+			amount: 0.040
 		}
 		{
 			type: "work"
 			work: "assembling"
-			amount: 50.000
-			difficulty: 5.000
+			amount: 8.000
+			difficulty: 4.000
 		}
 	]
 	

--- a/content/Recipes/Gunsmith/recipe.gunsmith.ammo_sg.buck.hjson
+++ b/content/Recipes/Gunsmith/recipe.gunsmith.ammo_sg.buck.hjson
@@ -13,9 +13,9 @@
 		frame: [3, 0]
 	}
 	
-	min: 4
+	min: 10
 	max: 100
-	step: 4
+	step: 10
 	type: workshop
 	tags: gunsmith
 	
@@ -24,23 +24,23 @@
 		{
 			type: "resource"
 			material: "iron_ingot"
-			amount: 0.125
+			amount: 0.050
 		}
 		{
 			type: "resource"
 			material: "copper_ingot"
-			amount: 0.250
+			amount: 0.040
 		}
 		{
 			type: "resource"
 			material: "nitrocellulose"
-			amount: 0.250
+			amount: 0.040
 		}
 		{
 			type: "work"
 			work: "assembling"
-			amount: 50.000
-			difficulty: 5.000
+			amount: 8.000
+			difficulty: 4.000
 		}
 	]
 	

--- a/content/Recipes/Gunsmith/recipe.gunsmith.ammo_sg.grenade.hjson
+++ b/content/Recipes/Gunsmith/recipe.gunsmith.ammo_sg.grenade.hjson
@@ -12,9 +12,9 @@
 		frame: [3, 0]
 	}
 	
-	min: 4
+	min: 10
 	max: 100
-	step: 4
+	step: 10
 	type: workshop
 	tags: gunsmith
 	
@@ -23,17 +23,17 @@
 		{
 			type: "resource"
 			material: "copper_ingot"
-			amount: 0.250
+			amount: 0.020
 		}
 		{
 			type: "resource"
 			material: "nitrocellulose"
-			amount: 2.500
+			amount: 0.280
 		}
 		{
 			type: "work"
 			work: "assembling"
-			amount: 40.000
+			amount: 16.000
 			difficulty: 4.000
 		}
 	]

--- a/content/Recipes/Gunsmith/recipe.gunsmith.ammo_sg.slug.gp.hjson
+++ b/content/Recipes/Gunsmith/recipe.gunsmith.ammo_sg.slug.gp.hjson
@@ -13,9 +13,9 @@
 		frame: [3, 0]
 	}
 	
-	min: 4
+	min: 10
 	max: 100
-	step: 4
+	step: 10
 	type: workshop
 	tags: gunsmith
 	
@@ -24,22 +24,22 @@
 		{
 			type: "resource"
 			material: "iron_ingot"
-			amount: 0.125
+			amount: 0.050
 		}
 		{
 			type: "resource"
 			material: "copper_ingot"
-			amount: 0.250
+			amount: 0.040
 		}
 		{
 			type: "resource"
 			material: "gunpowder"
-			amount: 0.250
+			amount: 0.040
 		}
 		{
 			type: "work"
 			work: "assembling"
-			amount: 40.000
+			amount: 8.000
 			difficulty: 4.000
 		}
 	]

--- a/content/Recipes/Gunsmith/recipe.gunsmith.ammo_sg.slug.hjson
+++ b/content/Recipes/Gunsmith/recipe.gunsmith.ammo_sg.slug.hjson
@@ -13,9 +13,9 @@
 		frame: [3, 0]
 	}
 	
-	min: 4
+	min: 10
 	max: 100
-	step: 4
+	step: 10
 	type: workshop
 	tags: gunsmith
 	
@@ -24,22 +24,22 @@
 		{
 			type: "resource"
 			material: "iron_ingot"
-			amount: 0.125
+			amount: 0.050
 		}
 		{
 			type: "resource"
 			material: "copper_ingot"
-			amount: 0.250
+			amount: 0.040
 		}
 		{
 			type: "resource"
 			material: "nitrocellulose"
-			amount: 0.250
+			amount: 0.040
 		}
 		{
 			type: "work"
 			work: "assembling"
-			amount: 40.000
+			amount: 8.000
 			difficulty: 4.000
 		}
 	]

--- a/content/Recipes/Gunsmith/recipe.gunsmith.ammo_shell.hjson
+++ b/content/Recipes/Gunsmith/recipe.gunsmith.ammo_shell.hjson
@@ -20,7 +20,7 @@
 		{
 			type: "resource"
 			material: "iron_ingot"
-			amount: 5.000
+			amount: 8.000
 		}
 		{
 			type: "resource"

--- a/content/Recipes/Gunsmith/recipe.gunsmith.ammo_shell.shrapnel.hjson
+++ b/content/Recipes/Gunsmith/recipe.gunsmith.ammo_shell.shrapnel.hjson
@@ -20,7 +20,7 @@
 		{
 			type: "resource"
 			material: "iron_ingot"
-			amount: 10.000
+			amount: 12.000
 		}
 		{
 			type: "resource"

--- a/content/Recipes/Gunsmith/recipe.gunsmith.grenade.hjson
+++ b/content/Recipes/Gunsmith/recipe.gunsmith.grenade.hjson
@@ -19,13 +19,18 @@
 	[
 		{
 			type: "resource"
+			material: "wood"
+			amount: 5.000
+		}
+		{
+			type: "resource"
 			material: "gunpowder"
-			amount: 15.000
+			amount: 2.000
 		}
 		{
 			type: "resource"
 			material: "iron_ingot"
-			amount: 0.500
+			amount: 1.000
 		}
 		{
 			type: "resource"

--- a/content/Recipes/Press/recipe.press.ammo_hc.hjson
+++ b/content/Recipes/Press/recipe.press.ammo_hc.hjson
@@ -22,17 +22,17 @@
 		{
 			type: "resource"
 			material: "iron_ingot"
-			amount: 2.000
+			amount: 1.500
 		}
 		{
 			type: "resource"
 			material: "copper_ingot"
-			amount: 1.000
+			amount: 0.500
 		}
 		{
 			type: "resource"
 			material: "gunpowder"
-			amount: 1.500
+			amount: 4.000
 		}
 		{
 			type: "work"
@@ -47,7 +47,7 @@
 		{
 			type: "resource"
 			material: "ammo_hc"
-			amount: 10.000
+			amount: 50.000
 		}
 	]
 }

--- a/content/Recipes/Press/recipe.press.ammo_hc.hv.hjson
+++ b/content/Recipes/Press/recipe.press.ammo_hc.hv.hjson
@@ -22,17 +22,17 @@
 		{
 			type: "resource"
 			material: "iron_ingot"
-			amount: 2.000
+			amount: 1.500
 		}
 		{
 			type: "resource"
 			material: "copper_ingot"
-			amount: 1.000
+			amount: 0.500
 		}
 		{
 			type: "resource"
 			material: "nitrocellulose"
-			amount: 1.500
+			amount: 4.000
 		}
 		{
 			type: "work"
@@ -47,7 +47,7 @@
 		{
 			type: "resource"
 			material: "ammo_hc.hv"
-			amount: 10.000
+			amount: 50.000
 		}
 	]
 }

--- a/content/Recipes/Press/recipe.press.ammo_lc.hjson
+++ b/content/Recipes/Press/recipe.press.ammo_lc.hjson
@@ -22,12 +22,12 @@
 		{
 			type: "resource"
 			material: "iron_ingot"
-			amount: 0.500
+			amount: 0.750
 		}
 		{
 			type: "resource"
 			material: "copper_ingot"
-			amount: 0.500
+			amount: 0.750
 		}
 		{
 			type: "resource"
@@ -47,7 +47,7 @@
 		{
 			type: "resource"
 			material: "ammo_lc"
-			amount: 10.000
+			amount: 50.000
 		}
 	]
 }

--- a/content/Recipes/Press/recipe.press.ammo_lc.hv.hjson
+++ b/content/Recipes/Press/recipe.press.ammo_lc.hv.hjson
@@ -22,12 +22,12 @@
 		{
 			type: "resource"
 			material: "iron_ingot"
-			amount: 0.500
+			amount: 0.750
 		}
 		{
 			type: "resource"
 			material: "copper_ingot"
-			amount: 0.500
+			amount: 0.750
 		}
 		{
 			type: "resource"
@@ -47,7 +47,7 @@
 		{
 			type: "resource"
 			material: "ammo_lc.hv"
-			amount: 10.000
+			amount: 50.000
 		}
 	]
 }

--- a/content/Recipes/Press/recipe.press.ammo_mg.hjson
+++ b/content/Recipes/Press/recipe.press.ammo_mg.hjson
@@ -22,17 +22,17 @@
 		{
 			type: "resource"
 			material: "iron_ingot"
-			amount: 4.000
+			amount: 1.600
 		}
 		{
 			type: "resource"
 			material: "copper_ingot"
-			amount: 1.500
+			amount: 0.400
 		}
 		{
 			type: "resource"
 			material: "nitrocellulose"
-			amount: 4.000
+			amount: 5.000
 		}
 		{
 			type: "work"


### PR DESCRIPTION
Resulting game changes of ammo crafting and weight rework:

- Crafting ammo from mats is way more effective than before, creating 50 round batch at minimum of some ammo from a single work order (LC, HC), while MG ammo and shotgun ammo are made in 10 per work order at minimum (mats cost in recipes is per round)

- Stamping press gives a massive advantage on crafting ammo because it's much faster than the workbench, opening a path to sustainable automatic guns

- Mats weight loss is around 2x for most ammo, which is way more sane than before, if there will be metal shavings as a material they should appear as 1/3 of the iron or copper cost (per metal weight) of ammo after the ammo is produced, propellant (nitrocellulose or gunpowder) has around 2x mats weight loss

- The ammo with almost no mats weight loss are the artillery shells (that shouldn't give metal shavings if they will be in the game)

- Musket ammo has almost no gunpowder mat weight loss, iron ingot mat weight loss is around 2x (almost ideal use of gunpowder per weight is made for gameplay reasons in this case)

- Grenade materials cost is reworked, continued to be crafted in a batch of 2 per work order, same with the kag-like bomb

- Rocket ammo materials cost is left unchanged because it has reasonable mats weight loss

- Weight is changed on somme ammo to reflect their closest real analogs

- Gunpowder has the same weight per unit as the nitrocellulose, nitrocellulose now stacks up to 500 for consistency with gunpowder

- MG ammo stacks up to 25 per inventory slot (for balance reasons and because these rounds are much bigger than regular rifle rounds)

- AC ammo stacks up to 10 per inventory slot (for balance reasons and because these rounds are huge)

- Musket ammo (all variants) now stack up to 24 per inventory slot, like the shotgun rounds

- You can't install "Caliber conversion" on autocannon anymore

- Work times are adjusted to be a bit faster when crafting at the gunsmith, to improve the gameplay


  These values are the result of careful calculation, they aren't arbitrary, I used the closest real analogs of TC2 ammo to calculate the needed metal mass and propellant mass (and explosive charge filling for explosive ammo) and then doubled the cost in most cases to represent the material loss during the creation, which resulted in surprising gamepaly choices:

- LC ammo is most useful when your factory has decent amounts of metal ingots but low amounts of propellant (nitrocellulose or gunpowder) and there is a need of mass produced ammo

- HC ammo is most useful when your factory has decent amounts of metal ingots and propellant and there is a need of mass produced ammo

- Shotgun ammo is most useful when your factory has a lot of metal ingots but low amounts of propellant and there is a need of stronger rounds

- MG ammo is most useful when your factory has lots of metal ingots and nitrocellulose and there is a need of extremely powerful rounds

- AC ammo (both variants) is quite costly to make, which balances its extreme power

- Artillery shell ammo (both variants) is very costly to make, making the mass production of it reserved to big and well developed factories, though the shrapnel variant requires much less nitrocellulose

-----

Potential ways of in-game research in the future:

- Unlocking recipes for ammo types which aren't normally available in the stamping press: grenade shotgun ammo, autocannon ammo, rocket ammo and perhaps the artillery shells, resulting in a mass production of these ammo types

-----

So in total it's a massive overhaul which greatly improves the game, a product of long research and tweaking