### PR TITLE
Changes Trashcans and Car Wrecks to have invs

### DIFF
--- a/content/Entities/Items/TrashCan/prefab.trashcan.hjson
+++ b/content/Entities/Items/TrashCan/prefab.trashcan.hjson
@@ -48,6 +48,22 @@ transform:
 
 }
 
+storage:
+{
+	@inventory2:
+	{
+		name: "Rummage Can"
+		stack_size_multiplier: 2.000
+		type: storage
+		flags: ignore_mass, public
+	}
+}
+
+interactable:
+{
+	window_size: [48.000, 96.000]
+}
+
 cover:
 {
 	threshold: 0.500

--- a/content/Entities/Items/TrashCan/prefab.wreck.trashcan.hjson
+++ b/content/Entities/Items/TrashCan/prefab.wreck.trashcan.hjson
@@ -45,6 +45,22 @@ transform:
 
 }
 
+storage:
+{
+	@inventory2:
+	{
+		name: "Rummage Can"
+		stack_size_multiplier: 2.000
+		type: storage
+		flags: ignore_mass, public
+	}
+}
+
+interactable:
+{
+	window_size: [48.000, 96.000]
+}
+
 harvestable:
 {
 	resources:

--- a/content/Entities/Structures/Wreck/prefab.wreck.car.hjson
+++ b/content/Entities/Structures/Wreck/prefab.wreck.car.hjson
@@ -73,6 +73,22 @@ harvestable:
 	]
 }
 
+storage:
+{
+	@inventory4:
+	{
+		name: "Trunk"
+		stack_size_multiplier: 4.000
+		type: storage
+		flags: ignore_mass, public
+	}
+}
+
+interactable:
+{
+	window_size: [192.000, 48.000]
+}
+
 cover:
 {
 	threshold: 0.200


### PR DESCRIPTION
- Car Wreck now has a 4x1 inventory with a x4 multiplier.
- Trash Can and Trashed Trash Can now have 1x2 inventories with x2 multiplier.
Tested fully in singleplayer.