### PR TITLE
Temp Fix for Machine parts

### DIFF
--- a/content/Recipes/Market/recipe.market.copper_ingot.buy.hjson
+++ b/content/Recipes/Market/recipe.market.copper_ingot.buy.hjson
@@ -13,9 +13,9 @@
 		frame: [3, 0]
 	}
 	
-	min: 10
+	min: 5
 	max: 50
-	step: 10
+	step: 5
 	type: buy
 	tags: market
 	
@@ -23,7 +23,7 @@
 	[
 		{
 			type: "money"
-			amount: 24.999
+			amount: 79.999
 		}
 	]
 	

--- a/content/Recipes/Market/recipe.market.iron_ingot.buy.hjson
+++ b/content/Recipes/Market/recipe.market.iron_ingot.buy.hjson
@@ -13,9 +13,9 @@
 		frame: [3, 0]
 	}
 	
-	min: 10
+	min: 5
 	max: 50
-	step: 10
+	step: 5
 	type: buy
 	tags: market
 	
@@ -23,7 +23,7 @@
 	[
 		{
 			type: "money"
-			amount: 9.999
+			amount: 29.999
 		}
 	]
 	

--- a/content/Recipes/Market/recipe.market.machine_parts.sell.hjson
+++ b/content/Recipes/Market/recipe.market.machine_parts.sell.hjson
@@ -39,7 +39,7 @@
 	[
 		{
 			type: "money"
-			amount: 13.790
+			amount: 10.790
 		}
 	]
 }


### PR DESCRIPTION
- This is a TEMPORARY fix, to make rounds less monotonous for those who know the machine part strat, until we get supply+demand simulation.
- Previously: Machine parts had a +324% profit margin, along with being the only current way of turning production into cash, thus destroying any sense of economy.
- Machine part sell price has been slightly nerfed, I didn't wanna touch it too much so that making parts with your mined ore is still really profitable.
- As a result, raised Copper and Iron buy costs from shop to match the general range of machine parts. Copper and Iron were far too cheap anyway, and made smelting those metals somewhat pointless.
- Copper and Iron buy amounts have been changed to 5 minimum since lower increments will make dealing with the higher price easier.
- The profit per five parts is now roughly 4 coins, instead of roughly 55 coins. This sounds like an extreme nerf, but it's only because the profit margin was so extreme before. In practise with a decent factory you'll still make money, just not enough to trivialise the game.